### PR TITLE
interpolate_via_density fix & tests for density

### DIFF
--- a/src/interpolate-paths.jl
+++ b/src/interpolate-paths.jl
@@ -162,15 +162,14 @@ function interpolate_via_density(kp::KPath{D}, density::Real) where D
             distᵢ = norm(kᶜᵢ₊₁ - kᶜᵢ)
             Nᵢ    = max(ceil(Int, distᵢ*density), 2)
 
-            # compute interpolation of current segment (excluding end point)
+            # compute interpolation of current segment
             kᵢ    = points(kp)[klabᵢ]
             kᵢ₊₁  = points(kp)[klabᵢ₊₁]
-            ks    = range(kᵢ, kᵢ₊₁, length=Nᵢ)[1:end-1]
+            ks    = range(kᵢ, kᵢ₊₁, length=Nᵢ)[1:end]
 
             append!(kipaths[j], ks)
-            push!(labels[j], length(kipaths[j])+1 => klabᵢ₊₁)
+            push!(labels[j], length(kipaths[j]) => klabᵢ₊₁)
         end
-        push!(kipaths[j], points(kp)[last(path)]) # add previously omitted end point
     end
 
     return KPathInterpolant(kipaths, labels, basis(kp), Ref(setting(kp)))

--- a/test/kpaths.jl
+++ b/test/kpaths.jl
@@ -141,7 +141,13 @@ using Brillouin.KPaths: cartesianize, latticize
         min_points = tot_dist*ρ - segments
         @test length(kpi_ρ) > min_points
 
-        # TODO: test that the density of k-points is _at least_ equal to ρ at every segment
+        # test that the density of k-points is _at least_ equal to ρ at every segment
+        for (i, path) in enumerate(paths(kp))
+	    klabels = Dict(value => key for (key, value) in kpi_ρ.labels[i])
+	    for j=1:length(path)-1
+		@test (klabels[path[j+1]] - klabels[path[j]]) >= ρ
+	    end
+	end
     end
 
     # interpolate with wrong kwargs


### PR DESCRIPTION
Hi!

For some reason the previous version of ``interpolate_via_density`` was not including the end points, such that if the path was Gamma -> X -> U, the points k-points would not return such that there were segments along Gamma -> X, then X -> U (this is the way pymatgen returns in the kpoints).

I added a little test as well to make sure that the number of points along each of the segments is _at least_ equal to the density.