### PR TITLE
Fix #12: (re-)implement `latticize(..., basis)`

### DIFF
--- a/src/Brillouin.jl
+++ b/src/Brillouin.jl
@@ -38,7 +38,7 @@ a (explicitly or implicitly specified) lattice basis.
 """
 function latticize end
 latticize(v::AVec{<:Real}, basismatrix::AbstractMatrix{<:Real}) = basismatrix\v
-latticize(v::AVec{<:Real}, basis::AVec{<:AVec{<:Real}}) = latticize(v, hcat(basis...))
+latticize(v::AVec{<:Real}, basis::AVec{<:AVec{<:Real}}) = latticize(v, reduce(hcat, basis))
 latticize(x) = (setting(x) === CARTESIAN ? latticize!(deepcopy(x)) : deepcopy(x))
 
 # TODO: Move "root" definition of `cartesianize(!)` and `latticize(!)` to Bravais, so we

--- a/test/kpaths.jl
+++ b/test/kpaths.jl
@@ -52,10 +52,14 @@ using Brillouin.KPaths: cartesianize, latticize, Bravais
         klab == klab′ && kv'pGs ≈ kv′
     end
     kp′′ = Brillouin.latticize(kp′)
-    @test keys(points(kp′′)) == keys(points(kp)) # point labels agree
-    @test paths(kp′′)        == paths(kp)        # segments agree
+    @test keys(points(kp′′)) == keys(points(kp))          # point labels agree
+    @test paths(kp′′) == paths(kp)                        # segments agree
     @test all(values(points(kp′′)) .≈ values(points(kp))) # point coordinates approx. agree
-    
+    kp′′′ = Brillouin.cartesianize!(Brillouin.latticize(kp′, pGs[[2,3,1]]))
+    @test keys(points(kp′′′)) == keys(points(kp′))
+    @test paths(kp′′′) == paths(kp′)
+    @test all(values(points(kp′′′)) .≈ values(points(kp′)))
+
     # `extended_bravais` and `irrfbz_path`
     sgnums = (1:2, 1:17, 1:230)
     for D in (1, 2, 3)
@@ -126,7 +130,9 @@ using Brillouin.KPaths: cartesianize, latticize, Bravais
 
     @test typeof(kpi) === typeof(kpi′) === KPathInterpolant{2}
     @test kpi′ ≈ kpi # test that `interpolate` commutes with `latticize`/`cartesianize`
-    @test Brillouin.cartesianize!(latticize!(kpi)) ≈ kpi
+    @test Brillouin.cartesianize!(latticize!(kpi)) ≈ kpi′
+
+    @test Brillouin.cartesianize!(Brillouin.latticize(kpi, pGs[[2,1]])) ≈ kpi′
 
     # interpolate via `density` kwarg
     kp = irrfbz_path(227, Rsᶜᶸᵇⁱᶜ)

--- a/test/wignerseitz.jl
+++ b/test/wignerseitz.jl
@@ -102,6 +102,11 @@ using StaticArrays
     test_show(cell, cell_show_reference)
     test_show(Brillouin.cartesianize(cell), cell_show_referenceᶜ)
 
+    # cartesianize/latticize(!)
+    @test Brillouin.latticize!(Brillouin.cartesianize!(deepcopy(cell))) ≈ cell
+    cellᶜ = Brillouin.cartesianize!(deepcopy(cell))
+    @test Brillouin.cartesianize!(Brillouin.latticize(cellᶜ, basis(cell)[[3,2,1]])) ≈ cellᶜ
+
     # test indexing/iteration of Cell struct
     @test cell[1] ≈ [[-2/3,  1/3, -1/2],
                      [-2/3,  1/3, 1/2],


### PR DESCRIPTION
Does this cover your use-cases @jaemolihm? This implements `latticize(::T, basis)` for `T = Union{Cell, KPath, KPathInterpolant}` (and does a bit of fly-by clean-up in the process; bit noisier commit than necessary as a result).

As you also noted in #13, it is not possible to do this in-place since the `basis` field of `Cell`, `KPath`, etc. is immutable - so it seems this has to be in the form of `latticize` rather than `latticize!`.

Fixes #12.