### PR TITLE
High-symmetry kpath for non-standard lattices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,3 +24,4 @@ julia = "1.6"
 [extras]
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+Spglib = "f761d5c5-86db-4880-b97f-9680a7cccfb5"

--- a/docs/src/kpaths.md
+++ b/docs/src/kpaths.md
@@ -85,4 +85,32 @@ Main.HTMLPlot(P¹², 525) # hide
 plot(::KPathInterpolant, ::Any, ::Layout)
 ```
 
+## K-paths for non-standard lattices
+One can create a **k**-path for a non-standard unit cell by using Spglib.
+```@example kpath
+using Spglib
+# Trigonal lattice, space group R-3m, 166
+a = 1.0
+c = 8.0
+lattice_standard    = SVector(SVector(a*sqrt(3)/2,  a/2, c/3),
+                              SVector(-a*sqrt(3)/2, a/2, c/3),
+                              SVector(0.0, -a, c/3))
+lattice_nonstandard = SVector(SVector(a*sqrt(3)/2, -a/2, c/3),
+                              SVector(0.0, a, c/3),
+                              SVector(-a*sqrt(3)/2, -a/2, c/3))
+
+cell_standard = Spglib.Cell(lattice_standard, [[0, 0, 0]], [0])
+cell_nonstandard = Spglib.Cell(lattice_nonstandard, [[0, 0, 0]], [0])
+
+kp_standard = irrfbz_path(cell_standard)
+kp_nonstandard = irrfbz_path(cell_nonstandard)
+```
+
+One can check that the generated **k**-paths for the non-standard and standard lattice vectors are equivalent by plotting the path and the Wigner-Seitz cell.
+```@example kpath
+using Bravais
+PlotlyJS.plot(wignerseitz(Bravais.reciprocalbasis(Bravais.DirectBasis(lattice_standard))), kp_standard, Layout(title="standard cell"))
+PlotlyJS.plot(wignerseitz(Bravais.reciprocalbasis(Bravais.DirectBasis(lattice_nonstandard))), kp_nonstandard, Layout(title="non-standard cell"))
+```
+
 [^1] See e.g. [http://www.physics.rutgers.edu/~eandrei/chengdu/reading/tight-binding.pdf](http://www.physics.rutgers.edu/~eandrei/chengdu/reading/tight-binding.pdf)

--- a/docs/src/kpaths.md
+++ b/docs/src/kpaths.md
@@ -86,21 +86,21 @@ plot(::KPathInterpolant, ::Any, ::Layout)
 ```
 
 ## K-paths for non-standard lattices
-One can create a **k**-path for a non-standard unit cell by using Spglib.
+One can create a **k**-path for a non-standard primitive unit cell by using Spglib.
 ```@example kpath
 using Spglib
 # Trigonal lattice, space group R-3m, 166
 a = 1.0
 c = 8.0
-lattice_standard    = SVector(SVector(a*sqrt(3)/2,  a/2, c/3),
-                              SVector(-a*sqrt(3)/2, a/2, c/3),
-                              SVector(0.0, -a, c/3))
-lattice_nonstandard = SVector(SVector(a*sqrt(3)/2, -a/2, c/3),
-                              SVector(0.0, a, c/3),
-                              SVector(-a*sqrt(3)/2, -a/2, c/3))
+pRs_standard    = [[a*√3/2,  a/2, c/3],
+                   [-a*√3/2, a/2, c/3],
+                   [0, -a, c/3]]
+pRs_nonstandard = [[a*√3/2, -a/2, c/3],
+                   [0, a, c/3],
+                   [-a*√3/2, -a/2, c/3]]
 
-cell_standard = Spglib.Cell(lattice_standard, [[0, 0, 0]], [0])
-cell_nonstandard = Spglib.Cell(lattice_nonstandard, [[0, 0, 0]], [0])
+cell_standard = Spglib.Cell(pRs_standard, [[0, 0, 0]], [0])
+cell_nonstandard = Spglib.Cell(pRs_nonstandard, [[0, 0, 0]], [0])
 
 kp_standard = irrfbz_path(cell_standard)
 kp_nonstandard = irrfbz_path(cell_nonstandard)
@@ -109,8 +109,8 @@ kp_nonstandard = irrfbz_path(cell_nonstandard)
 One can check that the generated **k**-paths for the non-standard and standard lattice vectors are equivalent by plotting the path and the Wigner-Seitz cell.
 ```@example kpath
 using Bravais
-PlotlyJS.plot(wignerseitz(Bravais.reciprocalbasis(Bravais.DirectBasis(lattice_standard))), kp_standard, Layout(title="standard cell"))
-PlotlyJS.plot(wignerseitz(Bravais.reciprocalbasis(Bravais.DirectBasis(lattice_nonstandard))), kp_nonstandard, Layout(title="non-standard cell"))
+plot(wignerseitz(reciprocalbasis(DirectBasis(pRs_standard))), kp_standard, Layout(title="standard cell"))
+plot(wignerseitz(reciprocalbasis(DirectBasis(pRs_nonstandard))), kp_nonstandard, Layout(title="non-standard cell"))
 ```
 
 [^1] See e.g. [http://www.physics.rutgers.edu/~eandrei/chengdu/reading/tight-binding.pdf](http://www.physics.rutgers.edu/~eandrei/chengdu/reading/tight-binding.pdf)

--- a/src/Brillouin.jl
+++ b/src/Brillouin.jl
@@ -104,7 +104,7 @@ function __init__()
     end
 
     @require Spglib="f761d5c5-86db-4880-b97f-9680a7cccfb5" begin
-        include("spglib.jl")
+        include("requires/spglib.jl")
     end
 end
 

--- a/src/Brillouin.jl
+++ b/src/Brillouin.jl
@@ -102,6 +102,10 @@ function __init__()
         include("requires/plotlyjs_kpaths.jl")
         include("requires/plotlyjs_dispersion.jl")
     end
+
+    @require Spglib="f761d5c5-86db-4880-b97f-9680a7cccfb5" begin
+        include("spglib.jl")
+    end
 end
 
 # ---------------------------------------------------------------------------------------- #

--- a/src/requires/spglib.jl
+++ b/src/requires/spglib.jl
@@ -21,7 +21,8 @@ function irrfbz_path(cell::Spglib.Cell)
 
     # If the input cell is a supercell (without any distortion), then the irrfbz algorithm cannot work.
     if !isapprox(det(cell.lattice), det(dset.primitive_lattice)) # check volumes agree
-        errror(DomainError(cell, "`cell` is a supercell and untreatable by `irrfbz_path`."))
+        error(DomainError(cell, "`cell` is a supercell and untreatable by `irrfbz_path`. " *
+            "If the cell represents a standard conventional lattice, use `irrfbz_path(sgnum::Integer, Rs)`"))
     end
 
     # Calculate kpath for standard primitive lattice
@@ -29,6 +30,8 @@ function irrfbz_path(cell::Spglib.Cell)
 
     # Now, we convert from the standard primitive lattice to the original lattice.
     # The conversion formula is `cell.lattice = rotation * dset.primitive_lattice * transformation`.
+    # `rotation` rotates the lattice vectors in 3D space.
+    # `transformation` is an integer-valued matrix that represents the linear combination of the lattice basis vectors.
     # `transformation` is not used, but is commented here just for information.
     # transformation = inv(Bravais.primitivebasismatrix(Bravais.centering(sgnum, 3))) * dset.transformation_matrix'
     rotation = dset.std_rotation_matrix

--- a/src/requires/spglib.jl
+++ b/src/requires/spglib.jl
@@ -1,19 +1,20 @@
 # Functionalities that are available when Spglib is loaded
 
-export irrfbz_path_for_cell
-
 using Bravais: reciprocalbasis, DirectBasis
 using LinearAlgebra
+import ..KPaths: irrfbz_path
+
+export irrfbz_path
 
 """
-    irrfbz_path_for_cell(cell::Spglib.Cell)  -->  ::KPath{D}
+    irrfbz_path(cell::Spglib.Cell)  -->  ::KPath{D}
 
 Returns a k-path for arbitrary 3D cell in the Spglib format. The k-path is equivalent to the
 "standard" k-path given by `irrfbz_path` for the equivalent standard primitive lattice.
 Does not give the correct k-path if the input cell is a supercell of a smaller primitive
 cell (a warning is printed).
 """
-function irrfbz_path_for_cell(cell::Spglib.Cell)
+function irrfbz_path(cell::Spglib.Cell)
     # standardize cell
     dset = Spglib.get_dataset(cell)
     sgnum = dset.spacegroup_number

--- a/src/spglib.jl
+++ b/src/spglib.jl
@@ -1,0 +1,45 @@
+# Functionalities that are available when Spglib is loaded
+
+export irrfbz_path_for_cell
+
+using Bravais: reciprocalbasis, DirectBasis
+using LinearAlgebra
+
+"""
+    irrfbz_path_for_cell(cell::Spglib.Cell)  -->  ::KPath{D}
+
+Returns a k-path for arbitrary 3D cell in the Spglib format. The k-path is equivalent to the
+"standard" k-path given by `irrfbz_path` for the equivalent standard primitive lattice.
+Does not give the correct k-path if the input cell is a supercell of a smaller primitive
+cell (a warning is printed).
+"""
+function irrfbz_path_for_cell(cell::Spglib.Cell)
+    # standardize cell
+    dset = Spglib.get_dataset(cell)
+    sgnum = dset.spacegroup_number
+    std_lattice = DirectBasis(collect(eachcol(dset.std_lattice)))
+
+    # If the input cell is a supercell (without any distortion), then the irrfbz algorithm cannot work.
+    # Check the volume of the input cell and primitive cell are equal.
+    if round(Int, det(cell.lattice) / det(dset.primitive_lattice)) != 1
+        @warn "input cell is a supercell. irrfbz Does not give a correct k path."
+    end
+
+    # Calculate kpath for standard primitive lattice
+    kp_standard = Brillouin.irrfbz_path(sgnum, std_lattice)
+
+    # Now, we convert from the standard primitive lattice to the original lattice.
+    # The conversion formula is `cell.lattice = rotation * dset.primitive_lattice * transformation`.
+    # `transformation` is not used, but is commented here just for information.
+    # transformation = inv(Bravais.primitivebasismatrix(Bravais.centering(sgnum, 3))) * dset.transformation_matrix'
+    rotation = dset.std_rotation_matrix
+
+    # Rotate k points in Cartesian space by `rotation`
+    recip_basis = reciprocalbasis(DirectBasis(collect(eachcol(Matrix(cell.lattice)))))
+    kp_cart = cartesianize(kp_standard)
+    for (lab, kv) in points(kp_cart)
+        points(kp_cart)[lab] = rotation * kv
+    end
+    kp = latticize(kp_cart, recip_basis)
+    kp
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,5 +2,6 @@
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+Spglib = "f761d5c5-86db-4880-b97f-9680a7cccfb5"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/kpaths_spglib.jl
+++ b/test/kpaths_spglib.jl
@@ -25,9 +25,9 @@ using Spglib
     cell_nonstandard = Spglib.Cell(lattice_nonstandard, [[0, 0, 0]], [0])
     cell_rotated = Spglib.Cell(lattice_rotated, [[0, 0, 0]], [0])
 
-    kp_standard = irrfbz_path_for_cell(cell_standard)
-    kp_nonstandard = irrfbz_path_for_cell(cell_nonstandard)
-    kp_rotated = irrfbz_path_for_cell(cell_rotated)
+    kp_standard = irrfbz_path(cell_standard)
+    kp_nonstandard = irrfbz_path(cell_nonstandard)
+    kp_rotated = irrfbz_path(cell_rotated)
 
     @test Bravais.reciprocalbasis(kp_standard.basis) ≈ lattice_standard
     @test Bravais.reciprocalbasis(kp_nonstandard.basis) ≈ lattice_nonstandard

--- a/test/kpaths_spglib.jl
+++ b/test/kpaths_spglib.jl
@@ -1,6 +1,5 @@
 using Brillouin, Test
 using Brillouin.KPaths: Bravais
-using StaticArrays
 using Spglib
 
 @testset "KPath for Spglib cell" begin
@@ -8,30 +7,28 @@ using Spglib
     # Example: Bi2Se3 (https://materialsproject.org/materials/mp-541837/)
     a = 1.0
     c = 8.0
-    lattice_nonstandard = SVector(SVector(a*sqrt(3)/2, -a/2, c/3),
-                                  SVector(0.0, a, c/3),
-                                  SVector(-a*sqrt(3)/2, -a/2, c/3))
-    conv_lattice = SVector(SVector(a*sqrt(3), 0, 0),
-                           SVector(-a*sqrt(3)/2, a*3/2, 0),
-                           SVector(0, 0, c))
-    sgnum = 166
-    lattice_standard = SVector(Bravais.primitivize(Bravais.DirectBasis(collect(conv_lattice)), Bravais.centering(sgnum, 3)))
+    pRs_standard    = [[a*√3/2,  a/2, c/3],
+                       [-a*√3/2, a/2, c/3],
+                       [0, -a, c/3]]
+    pRs_nonstandard = [[a*√3/2, -a/2, c/3],
+                       [0, a, c/3],
+                       [-a*√3/2, -a/2, c/3]]
 
     θ = 10 / 180 * pi
     rotation = [[cos(θ) sin(θ) 0]; [-sin(θ) cos(θ) 0]; [0 0 1]]
-    lattice_rotated = Ref(rotation) .* lattice_standard
+    pRs_rotated = Ref(rotation) .* pRs_standard
 
-    cell_standard = Spglib.Cell(lattice_standard, [[0, 0, 0]], [0])
-    cell_nonstandard = Spglib.Cell(lattice_nonstandard, [[0, 0, 0]], [0])
-    cell_rotated = Spglib.Cell(lattice_rotated, [[0, 0, 0]], [0])
+    cell_standard = Spglib.Cell(pRs_standard, [[0, 0, 0]], [0])
+    cell_nonstandard = Spglib.Cell(pRs_nonstandard, [[0, 0, 0]], [0])
+    cell_rotated = Spglib.Cell(pRs_rotated, [[0, 0, 0]], [0])
 
     kp_standard = irrfbz_path(cell_standard)
     kp_nonstandard = irrfbz_path(cell_nonstandard)
     kp_rotated = irrfbz_path(cell_rotated)
 
-    @test Bravais.reciprocalbasis(kp_standard.basis) ≈ lattice_standard
-    @test Bravais.reciprocalbasis(kp_nonstandard.basis) ≈ lattice_nonstandard
-    @test Bravais.reciprocalbasis(kp_rotated.basis) ≈ lattice_rotated
+    @test Bravais.reciprocalbasis(kp_standard.basis) ≈ pRs_standard
+    @test Bravais.reciprocalbasis(kp_nonstandard.basis) ≈ pRs_nonstandard
+    @test Bravais.reciprocalbasis(kp_rotated.basis) ≈ pRs_rotated
 
     @test kp_nonstandard.paths == kp_standard.paths
     @test kp_rotated.paths == kp_standard.paths

--- a/test/kpaths_spglib.jl
+++ b/test/kpaths_spglib.jl
@@ -1,0 +1,43 @@
+using Brillouin, Test
+using Brillouin.KPaths: Bravais
+using StaticArrays
+using Spglib
+
+@testset "KPath for Spglib cell" begin
+    # Trigonal lattice, space group R-3m, 166
+    # Example: Bi2Se3 (https://materialsproject.org/materials/mp-541837/)
+    a = 1.0
+    c = 8.0
+    lattice_nonstandard = SVector(SVector(a*sqrt(3)/2, -a/2, c/3),
+                                  SVector(0.0, a, c/3),
+                                  SVector(-a*sqrt(3)/2, -a/2, c/3))
+    conv_lattice = SVector(SVector(a*sqrt(3), 0, 0),
+                           SVector(-a*sqrt(3)/2, a*3/2, 0),
+                           SVector(0, 0, c))
+    sgnum = 166
+    lattice_standard = SVector(Bravais.primitivize(Bravais.DirectBasis(collect(conv_lattice)), Bravais.centering(sgnum, 3)))
+
+    θ = 10 / 180 * pi
+    rotation = [[cos(θ) sin(θ) 0]; [-sin(θ) cos(θ) 0]; [0 0 1]]
+    lattice_rotated = Ref(rotation) .* lattice_standard
+
+    cell_standard = Spglib.Cell(lattice_standard, [[0, 0, 0]], [0])
+    cell_nonstandard = Spglib.Cell(lattice_nonstandard, [[0, 0, 0]], [0])
+    cell_rotated = Spglib.Cell(lattice_rotated, [[0, 0, 0]], [0])
+
+    kp_standard = irrfbz_path_for_cell(cell_standard)
+    kp_nonstandard = irrfbz_path_for_cell(cell_nonstandard)
+    kp_rotated = irrfbz_path_for_cell(cell_rotated)
+
+    @test Bravais.reciprocalbasis(kp_standard.basis) ≈ lattice_standard
+    @test Bravais.reciprocalbasis(kp_nonstandard.basis) ≈ lattice_nonstandard
+    @test Bravais.reciprocalbasis(kp_rotated.basis) ≈ lattice_rotated
+
+    @test kp_nonstandard.paths == kp_standard.paths
+    @test kp_rotated.paths == kp_standard.paths
+
+    for (lab, kv) in kp_standard.points
+        @test kp_nonstandard.points[lab] ≈ kv
+        @test kp_rotated.points[lab] ≈ kv
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("testutils_show.jl")
 # core API/utilities
 include("kpaths.jl")
 include("wignerseitz.jl")
+include("kpaths_spglib.jl")
 
 # ---------------------------------------------------------------------------------------- #
 # optional plot utilities


### PR DESCRIPTION
As discussed in #13, I added `function irrfbz_path_for_cell(cell::Spglib.Cell)` in `src/spglib.jl`. I added a test that checks the k points (in lattice basis) are identical for standard and non-standard lattices.

The code is conditionally loaded only if Spglib is used via requires.