### PR TITLE
High-symmetry k path for supercells

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Brillouin"
 uuid = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"
 authors = ["Thomas Christensen <tchr@mit.edu> and contributors"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 Bravais = "ada6cbde-b013-4edf-aa94-f6abe8bd6e6b"

--- a/docs/src/kpaths.md
+++ b/docs/src/kpaths.md
@@ -88,7 +88,7 @@ plot(::KPathInterpolant, ::Any, ::Layout)
 ## Treating unit cells in non-standard settings
 `irrfbz_path(sgnum, Rs)` requires `Rs` to be provided in a standard setting. Often, the setting of `Rs` may not be standard and it can be a hassle to convert existing calculations to such a setting.
 To avoid this, we can provide the unit cell information to `irrfbz` via `Spglib`'s `Cell` format (this functionality depends on separately loading the [Spglib.jl](https://github.com/singularitti/Spglib.jl) package).
-The provided unit cell must be a primitive cell (that, additionally, is not a supercell of a smaller primitive cell).
+If the provided unit cell is a supercell of a smaller primitive cell, `irrfbz_path` returns the standard **k**-path of the smaller primitive cell in the basis of the supercell reciprocal lattice vectors.
 
 For example, to construct a **k**-path for a non-standard trigonal lattice in space group 166 (R-3m):
 ```@example kpath

--- a/src/requires/spglib.jl
+++ b/src/requires/spglib.jl
@@ -13,8 +13,8 @@ The **k**-path is equivalent to the standard **k**-path given by `irrfbz_path` f
 associated standard primitive lattice, but adapted to the possibly non-standard setting of
 `cell`.
 
-Note that `cell` must be a primitive unit cell and also cannot be a supercell of a smaller
-primitive cell.
+If `cell` is a supercell of a smaller primitive cell, return the standard **k**-path of the
+primitive cell in the basis of supercell reciprocal lattices.
 """
 function irrfbz_path(cell::Spglib.Cell)
     # extract a standardized primitive basis `pRs` assoc. w/ `cell` via Spglib
@@ -22,12 +22,10 @@ function irrfbz_path(cell::Spglib.Cell)
     sgnum = dset.spacegroup_number
     pRs = SVector{3}(SVector{3,Float64}(col) for col in eachcol(dset.std_lattice))
 
-    # if the input cell is a supercell (without any distortion), then the irrfbz algorithm
-    # cannot work
+    # print warning if the input cell is a supercell (without any distortion)
     if !isapprox(det(cell.lattice), det(dset.primitive_lattice)) # check volumes agree
-        error(DomainError(cell, 
-            "`cell` is either not primitive or a supercell and is untreatable by " * 
-            "`irrfbz_path(::Spglib.Cell)`"))
+        (@warn "$cell `cell` is a supercell. The resulting **k**-path is the standard " *
+            "**k**-path of the primitive cell in the basis of supercell reciprocal lattices.")
     end
 
     # Calculate kpath for standard primitive lattice

--- a/src/requires/spglib.jl
+++ b/src/requires/spglib.jl
@@ -13,8 +13,8 @@ The **k**-path is equivalent to the standard **k**-path given by `irrfbz_path` f
 associated standard primitive lattice, but adapted to the possibly non-standard setting of
 `cell`.
 
-If `cell` is a supercell of a smaller primitive cell, return the standard **k**-path of the
-primitive cell in the basis of supercell reciprocal lattices.
+If `cell` is a supercell of a smaller primitive cell, the standard **k**-path of the
+associated primitive cell is returned (in the basis of supercell reciprocal lattice).
 """
 function irrfbz_path(cell::Spglib.Cell)
     # extract a standardized primitive basis `pRs` assoc. w/ `cell` via Spglib
@@ -24,8 +24,8 @@ function irrfbz_path(cell::Spglib.Cell)
 
     # print warning if the input cell is a supercell (without any distortion)
     if !isapprox(det(cell.lattice), det(dset.primitive_lattice)) # check volumes agree
-        (@warn "$cell `cell` is a supercell. The resulting **k**-path is the standard " *
-            "**k**-path of the primitive cell in the basis of supercell reciprocal lattices.")
+        @warn "The provided cell is a supercell: the returned k-path is the standard k-path " *
+              "of the associated primitive cell in the basis of the supercell reciprocal lattice." cell
     end
 
     # Calculate kpath for standard primitive lattice

--- a/test/kpaths_spglib.jl
+++ b/test/kpaths_spglib.jl
@@ -37,4 +37,19 @@ using Spglib
         @test points(kp_nonstandard)[lab] ≈ kv
         @test points(kp_rotated)[lab] ≈ kv
     end
+
+    # The case where the input cell is a supercell of a smaller primitive cell
+    pRs_super = [pRs_standard[1], pRs_standard[2], 2 .* pRs_standard[3]]
+    cell_super = Spglib.Cell(pRs_super, [[0, 0, 0], [0, 0, 0.5]], [0, 0])
+    kp_super = irrfbz_path(cell_super)
+
+    @test Bravais.reciprocalbasis(basis(kp_super)) ≈ pRs_super
+    @test paths(kp_super) == paths(kp_standard)
+
+    # Check that the Cartesian coordinates of the high-symmetry k points are identical
+    kp_standard_cart = cartesianize(kp_standard)
+    kp_super_cart = cartesianize(kp_super)
+    for (lab, kv) in points(kp_standard_cart)
+        @test points(kp_super_cart)[lab] ≈ kv
+    end
 end


### PR DESCRIPTION
This is a follow-up of #15.

`irrfbz_path(cell)` now gives high-symmetry k path also for supercells. The k path is that of the primitive cell, just in the basis of the supercell reciprocal lattice. A downside for this method is that the high symmetry k point labels lose their meaning (i.e. they are not at the high-symmetry points of the first BZ of the given supercell). Still, this method gives some standardized k path, which in my opinion is much better than giving nothing.

This solution was discussed with @mfherbst in https://github.com/JuliaMolSim/DFTK.jl/pull/555#discussion_r771175235

### Example
```julia
using Spglib
using PlotlyJS
using Brillouin
using Bravais

a = 3.0
pRs_primitive    = [[a, 0, 0],
                    [0, a, 0],
                    [0, 0, a]]
cell_primitive = Spglib.Cell(pRs_primitive, [[0, 0, 0]], [0])
kp_primitive = irrfbz_path(cell_primitive)

pRs_super        = [[a, 0, 0],
                    [0, a, 0],
                    [0, 0, 2a]]
cell_super_undistorted = Spglib.Cell(pRs_super, [[0, 0, 0], [0, 0, 0.5]], [0, 0])
kp_super_undistorted = irrfbz_path(cell_super_undistorted)

# combine traces and plot
p1 = PlotlyJS.plot(wignerseitz(reciprocalbasis(pRs_super)), kp_super_undistorted)
p2 = PlotlyJS.plot(wignerseitz(reciprocalbasis(pRs_primitive)))
ts = vcat(p1.plot.data, p2.plot.data)
PlotlyJS.plot(ts, p1.plot.layout; config=PlotConfig(responsive=true, displaylogo=false))
```

In the image, the smaller box is the BZ of the supercell, and the larger cube is the BZ of the supercell.
![image](https://user-images.githubusercontent.com/32537613/147740528-cfc70bc2-74c0-47d3-b5f2-800daea84d9d.png)

Note that the warning message is badly formatted (Array are printed before other text is printed). I think the use of `display` in https://github.com/singularitti/Spglib.jl/blob/master/src/model.jl#L140-L149 is the cause, but I am not sure.
```julia
julia> kp_super_undistorted = irrfbz_path(cell_super_undistorted)
3×3 StaticArrays.MMatrix{3, 3, Float64, 9} with indices SOneTo(3)×SOneTo(3):
 3.0  0.0  0.0
 0.0  3.0  0.0
 0.0  0.0  6.0
3×2 StaticArrays.MMatrix{3, 2, Float64, 6} with indices SOneTo(3)×SOneTo(2):
 0.0  0.0
 0.0  0.0
 0.0  0.5
┌ Warning: lattice:
│  2 atomic positions:
│  2 atoms:
│  [0, 0]
│  `cell` is a supercell. The resulting **k**-path is the standard **k**-path of the primitive cell in the basis of supercell reciprocal lattices.
└ @ Brillouin ~/.julia/dev/Brillouin/src/requires/spglib.jl:27
```