### PR TITLE
Fix Makie.plot aspect ratio

### DIFF
--- a/src/requires/makie_wignerseitz.jl
+++ b/src/requires/makie_wignerseitz.jl
@@ -39,7 +39,7 @@ function Makie.plot!(c::Union{Observable{<:Cell}, <:Cell}; kws...)
 end
 
 @inline _Axis_by_dim(D)   = D == 3 ? Makie.Axis3   : Makie.Axis
-@inline _aspect_by_dim(D) = D == 3 ? (1.0,1.0,1.0) : Makie.DataAspect()
+@inline _aspect_by_dim(D) = D == 3 ? :data : Makie.DataAspect()
 function Makie.plot(c::Union{Observable{Cell{D}}, Cell{D}};
                     axis = NamedTuple(), figure = NamedTuple(), kws...) where D
     f = Makie.Figure(; figure...)


### PR DESCRIPTION
When plotting using Makie, the aspect ratio was scaled to (1, 1, 1) meaning that the total lengths of the axes are scaled to be equal and the data is squished to fit inside a cube. However, the aspect ratio needs to be scaled to the lengths in data space to represent the real-world lengths.