### PR TITLE
Replace SciPy qhull by DirectQhull.jl (drop PyCall.jl)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,7 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-        env:
-          PYTHON: "" # the python version picked by PyCall.jl sometimes isn't Conda.jl's version, but the system's: this ensures that it is Conda.jl's
       - uses: julia-actions/julia-runtest@v1
-        env:
-          PYTHON: ""
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:
@@ -54,8 +50,6 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1
-        env:
-          PYTHON: ""
       - run: |
           julia --project=docs -e '
             using Pkg
@@ -67,10 +61,7 @@ jobs:
             using Documenter: doctest
             using Brillouin
             doctest(Brillouin)'
-        env:
-          PYTHON: ""
       - run: julia --project=docs docs/make.jl
         env:
-          PYTHON: ""
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,21 +1,21 @@
 name = "Brillouin"
 uuid = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"
 authors = ["Thomas Christensen <tchr@mit.edu> and contributors"]
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 Bravais = "ada6cbde-b013-4edf-aa94-f6abe8bd6e6b"
+DirectQhull = "c3f9d41a-afcb-471e-bc58-0b8d83bd86f4"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Bravais = "0.1.8"
+DirectQhull = "0.2"
 DocStringExtensions = "0.8, 0.9"
-PyCall = "1.92"
 Reexport = "1.0, 1.1, 1.2"
 Requires = "1.1"
 StaticArrays = "1.2"


### PR DESCRIPTION
DirectQhull.jl should now be functional across all platforms, so we can depend on that instead of getting qhull via PyCall.jl.

Fixes #22.