### PR TITLE
Add back `Spglib.jl` `v0.8` compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ PlotlyJS = "0.18"
 Reexport = "1"
 Requires = "1.1"
 PrecompileTools = "1"
-Spglib = "0.9"
+Spglib = "0.8, 0.9"
 StaticArrays = "1.2"
 julia = "1.6"
 


### PR DESCRIPTION
As discussed in #28, I add back `Spglib.jl` `v0.8` in the `[compat]` section in `Project.toml` since this package does not rely on the new features introduced in `v0.9`.