### PR TITLE
Fixes for Makie 0.24

### DIFF
--- a/ext/BrillouinMakieExt/kpaths.jl
+++ b/ext/BrillouinMakieExt/kpaths.jl
@@ -44,14 +44,14 @@ function Makie.plot!(kpp::KPathPlot{Tuple{KPath{D}}}) where D
     update_plot!(okp[]) # populate `segments`, `pts`, `labels`, `labelspos` for initial call
 
     Makie.lines!(kpp, segments;
-                 color = kpp.linecolor, linewidth = kpp.linewidth, kpp.linekws...)
+                 color = kpp.linecolor, linewidth = kpp.linewidth, to_value(kpp.linekws)...)
     Makie.scatter!(kpp, pts; 
                    color=kpp.markercolor, markersize=kpp.markersize, marker=:circle,
-                   kpp.markerkws...)
+                   to_value(kpp.markerkws)...)
     Makie.text!(kpp, labelspos[]; text=labels[],
                 align = (0.5,0.5), fontsize = 22,
                 color = kpp.textcolor, strokewidth = D==3 ? 2 : 0, strokecolor = :white,
-                kpp.textkws...)
+                to_value(kpp.textkws)...)
 
     return kpp
 end


### PR DESCRIPTION
The upgrade to Makie 0.24 is not yet working. Hopefully fixes can be collected in this PR.

Test case:
```jl
using Brillouin, GLMakie
sgnum = 227
Rs = [[1,0,0], [0,1,0], [0,0,1]] # conventional direct basis
kp = irrfbz_path(sgnum, Rs)
cartesianize(kp)
Pᵏ = plot(kp)
```

* Attributes need to be converted "to_value" for forwarding, as suggested here: https://github.com/thchr/Brillouin.jl/pull/40#issuecomment-3012678412

* Executing the above throws `Error showing value of type Makie.FigureAxisPlot:`, and unfortunately `showing an error caused an error`.

Full trace:

```
Error showing value of type Makie.FigureAxisPlot:

SYSTEM (REPL): showing an error caused an error
ERROR: KeyError: key :visible not found
Stacktrace:
  [1] print_response(errio::IO, response::Any, backend::Union{…}, show_value::Bool, have_color::Bool, specialdisplay::Union{…})
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/REPL.jl:446
  [2] (::REPL.var"#70#71"{REPL.LineEditREPL, Pair{Any, Bool}, Bool, Bool})(io::Any)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/REPL.jl:405
  [3] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/REPL.jl:678
  [4] print_response(repl::REPL.AbstractREPL, response::Any, show_value::Bool, have_color::Bool)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/REPL.jl:403
  [5] (::REPL.var"#do_respond#100"{…})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/REPL.jl:1035
  [6] #invokelatest#2
    @ ./essentials.jl:1055 [inlined]
  [7] invokelatest
    @ ./essentials.jl:1052 [inlined]
  [8] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/LineEdit.jl:2755
  [9] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/REPL.jl:1506
 [10] (::REPL.var"#79#85"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/REPL/src/REPL.jl:497
Some type information was truncated. Use `show(err)` to see complete types.
```